### PR TITLE
Add oauth 2.0 state field as a parameter to requestAccessUri

### DIFF
--- a/src/main/scala/codecheck/github/api/OAuthAPI.scala
+++ b/src/main/scala/codecheck/github/api/OAuthAPI.scala
@@ -28,6 +28,18 @@ class OAuthAPI(clientId: String, clientSecret: String, redirectUri: String, clie
     accessRequestUri +"?"+ query
   }
 
+  def requestAccessUri(state: String, scope: Seq[String]) = {
+    val params = Map[String, String](
+      "client_id" -> clientId,
+      "redirect_uri" -> redirectUri,
+      "scope" -> scope.mkString(","),
+      "response_type" -> "token",
+      "state" -> state
+    )
+    val query: String = params.map { case (k, v) => k +"="+ URLEncoder.encode(v, "utf-8") }.mkString("&")
+    accessRequestUri +"?"+ query
+  }
+
   def requestToken(code: String): Future[AccessToken] = {
     val params: Map[String, String] = Map(
       "client_id" -> clientId,


### PR DESCRIPTION
@shunjikonishi please review

In order for an application to properly check the oauth `state` parameter, it needs to generate the field by itself and pass it in to the OAuth URL generation function. This is similar to how facebook4j handles it: http://facebook4j.org/javadoc/facebook4j/auth/OAuthSupport.html#getOAuthAuthorizationURL(java.lang.String, java.lang.String)

`sbt test` was failing for me before I made any changes, so I'm not sure if this breaks any tests or not.
