### PR TITLE
Use type for issue state

### DIFF
--- a/src/main/scala/codecheck/github/models/Issue.scala
+++ b/src/main/scala/codecheck/github/models/Issue.scala
@@ -172,7 +172,7 @@ case class Issue(value: JValue) extends AbstractJson(value) {
     case _ => Nil
   }
 
-  def state = get("state")
+  def state = IssueState.fromString(get("state"))
   def locked = boolean("locked")
 
   lazy val assignee = objectOpt("assignee")(v => User(v))

--- a/src/main/scala/codecheck/github/models/PullRequest.scala
+++ b/src/main/scala/codecheck/github/models/PullRequest.scala
@@ -57,7 +57,7 @@ case class PullRequestRef(value: JValue) extends AbstractJson(value) {
 case class PullRequest(value: JValue) extends AbstractJson(value) {
   def number = get("number").toLong
   def body = get("body")
-  def state = get("state")
+  def state = IssueState.fromString(get("state"))
   def title = get("title")
   lazy val head = PullRequestRef(value \ "head")
   lazy val base = PullRequestRef(value \ "base")


### PR DESCRIPTION
This is a compatibility change, but it seems useful to lift an `IssueType` from the "state" string — either "open" or "closed" — from an issue or a pull request.

According to the docs for editing an issue, there are only two values:

https://developer.github.com/v3/issues/#edit-an-issue

And the same for pull requests:

https://developer.github.com/v3/pulls/#update-a-pull-request

However, `IssueType` is used in this library as an input parameter, and not a result value, so it includes "all" as a value.  Not sure if you want to correct that, or not.
