### PR TITLE
Add namespaces to test suite

### DIFF
--- a/src/test/scala/BranchOpSpec.scala
+++ b/src/test/scala/BranchOpSpec.scala
@@ -1,15 +1,13 @@
+package codecheck.github
+package operations
+
 import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfterAll
-import codecheck.github.exceptions.NotFoundException
-import codecheck.github.models._
-import codecheck.github.exceptions.GitHubAPIException
-import codecheck.github.exceptions.NotFoundException
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import codecheck.github.models.UserInput
 
 class BranchOpSpec extends FunSpec
-  with Constants
+  with api.Constants
   with BeforeAndAfterAll
 {
   describe("getBranch") {

--- a/src/test/scala/CollaboratorOpSpec.scala
+++ b/src/test/scala/CollaboratorOpSpec.scala
@@ -1,10 +1,13 @@
+package codecheck.github
+package operations
+
+import exceptions._
+
 import org.scalatest.path.FunSpec
 import scala.concurrent.Await
-import codecheck.github.models.Collaborator
-import codecheck.github.exceptions.GitHubAPIException
-import codecheck.github.exceptions.NotFoundException
 
-class CollaboratorOpSpec extends FunSpec with Constants {
+class CollaboratorOpSpec extends FunSpec with api.Constants
+{
 
   describe("addCollaborator"){
     it("should add Collaborator User to user Repo"){

--- a/src/test/scala/Constants.scala
+++ b/src/test/scala/Constants.scala
@@ -1,7 +1,9 @@
+package codecheck.github
+package api
+
+import transport.asynchttp20.AsyncHttp20Transport
+
 import org.asynchttpclient.DefaultAsyncHttpClient
-import codecheck.github.api.GitHubAPI
-import codecheck.github.api.PrintlnHandler
-import codecheck.github.transport.asynchttp20.AsyncHttp20Transport
 import scala.concurrent.duration._
 import scala.util.Random._
 import org.scalatest.time.Span._

--- a/src/test/scala/IssueOpSpec.scala
+++ b/src/test/scala/IssueOpSpec.scala
@@ -1,23 +1,15 @@
+package codecheck.github
+package operations
+
+import models._
+
 import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfterAll
 import scala.concurrent.Await
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 
-import codecheck.github.models.IssueListOption
-import codecheck.github.models.IssueFilter
-import codecheck.github.models.IssueListOption4Repository
-import codecheck.github.models.IssueState
-import codecheck.github.models.Issue
-import codecheck.github.models.IssueInput
-import codecheck.github.models.MilestoneSearchOption
-
-import codecheck.github.models.MilestoneInput
-import codecheck.github.models.MilestoneListOption
-import codecheck.github.models.MilestoneState
-import codecheck.github.models.Milestone
-
-class IssueOpSpec extends FunSpec with Constants with BeforeAndAfterAll {
+class IssueOpSpec extends FunSpec with api.Constants with BeforeAndAfterAll {
 
   val number = 1
   var nUser: Long = 0

--- a/src/test/scala/LabelOpSpec.scala
+++ b/src/test/scala/LabelOpSpec.scala
@@ -1,11 +1,13 @@
+package codecheck.github
+package operations
+
+import exceptions._
+import models._
+
 import org.scalatest.FunSpec
 import scala.concurrent.Await
-import codecheck.github.models.Label
-import codecheck.github.models.LabelInput
-import codecheck.github.exceptions.GitHubAPIException
-import codecheck.github.exceptions.NotFoundException
 
-class LabelOpSpec extends FunSpec with Constants {
+class LabelOpSpec extends FunSpec with api.Constants {
 
   val number = 1
   val gName = generateRandomWord

--- a/src/test/scala/MilestoneOpSpec.scala
+++ b/src/test/scala/MilestoneOpSpec.scala
@@ -1,18 +1,16 @@
+package codecheck.github
+package operations
+
+import exceptions._
+import models._
+
 import org.scalatest.path.FunSpec
-import codecheck.github.exceptions.NotFoundException
-import codecheck.github.models.Milestone
-import codecheck.github.models.MilestoneInput
-import codecheck.github.models.MilestoneListOption
-import codecheck.github.models.MilestoneState
-import codecheck.github.models.SortDirection
-import codecheck.github.exceptions.GitHubAPIException
-import codecheck.github.exceptions.NotFoundException
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.joda.time.DateTime
 
 class MilestoneOpSpec extends FunSpec
-  with Constants
+  with api.Constants
 {
 
   private def removeAll = {

--- a/src/test/scala/OraganizationOpSpec.scala
+++ b/src/test/scala/OraganizationOpSpec.scala
@@ -1,3 +1,6 @@
+package codecheck.github
+package operations
+
 import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfter
 import scala.concurrent.Await
@@ -6,7 +9,7 @@ import org.joda.time.DateTimeZone
 
 import codecheck.github.models.OrganizationInput
 
-class OrganizationOpSpec extends FunSpec with Constants with BeforeAndAfter {
+class OrganizationOpSpec extends FunSpec with api.Constants with BeforeAndAfter {
 
   describe("listOwnOrganizations") {
     it("should return result.") {

--- a/src/test/scala/PullRequestOpSpec.scala
+++ b/src/test/scala/PullRequestOpSpec.scala
@@ -1,10 +1,13 @@
+package codecheck.github
+package operations
+
+import models._
+
 import org.scalatest.FunSpec
 import scala.concurrent.Await
-
-import codecheck.github.models.PullRequestInput
 import java.util.Date
 
-class PullRequestOpSpec extends FunSpec with Constants {
+class PullRequestOpSpec extends FunSpec with api.Constants {
 
   describe("listPullRequests") {
     it("with valid repo should succeed") {

--- a/src/test/scala/RepositoryAPISpec.scala
+++ b/src/test/scala/RepositoryAPISpec.scala
@@ -1,6 +1,9 @@
+package codecheck.github
+package api
+
 import org.scalatest.FunSpec
 
-class RepositoryAPISpec extends FunSpec with Constants {
+class RepositoryAPISpec extends FunSpec with api.Constants {
 	
   val gDummy = generateRandomString
   val gRepo = generateRandomString

--- a/src/test/scala/RepositoryOpSpec.scala
+++ b/src/test/scala/RepositoryOpSpec.scala
@@ -1,13 +1,11 @@
+package codecheck.github
+package operations
+
 import org.scalatest.path.FunSpec
-import codecheck.github.exceptions.NotFoundException
-import codecheck.github.models.Repository
-import codecheck.github.models.RepositoryInput
-import codecheck.github.exceptions.GitHubAPIException
-import codecheck.github.exceptions.NotFoundException
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class RepositoryOpSpec extends FunSpec with Constants
+class RepositoryOpSpec extends FunSpec with api.Constants
 {
 
   describe("listOwnRepositories") {
@@ -89,7 +87,7 @@ class RepositoryOpSpec extends FunSpec with Constants
         val repo = Await.result(api.createUserRepository(input), TIMEOUT)
         fail
       } catch {
-        case e: GitHubAPIException =>
+        case e: ApiException =>
           assert(e.error.errors.head.field == "name")
         case e: Throwable =>
           fail

--- a/src/test/scala/UserOpSpec.scala
+++ b/src/test/scala/UserOpSpec.scala
@@ -1,15 +1,16 @@
+package codecheck.github
+package operations
+
+import exceptions._
+import models._
+
 import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfterAll
-import codecheck.github.exceptions.NotFoundException
-import codecheck.github.models.Repository
-import codecheck.github.exceptions.GitHubAPIException
-import codecheck.github.exceptions.NotFoundException
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import codecheck.github.models.UserInput
 
 class UserOpSpec extends FunSpec
-  with Constants
+  with api.Constants
   with BeforeAndAfterAll
 {
   val origin = Await.result(api.getAuthenticatedUser, TIMEOUT)

--- a/src/test/scala/WebhookOpSpec.scala
+++ b/src/test/scala/WebhookOpSpec.scala
@@ -1,15 +1,13 @@
+package codecheck.github
+package operations
+
+import models._
 
 import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfter
 import scala.concurrent.Await
 
-import codecheck.github.models.Webhook
-import codecheck.github.models.WebhookConfig
-import codecheck.github.models.WebhookCreateInput
-import codecheck.github.models.WebhookUpdateInput
-
-
-class WebhookOpSpec extends FunSpec with Constants with BeforeAndAfter {
+class WebhookOpSpec extends FunSpec with api.Constants with BeforeAndAfter {
 
   val targetURL = "http://github-hook.herokuapp.com/hook"
   var nID: Long = 0;

--- a/src/test/scala/events/IssueEventJson.scala
+++ b/src/test/scala/events/IssueEventJson.scala
@@ -1,4 +1,5 @@
-package codecheck.github.events
+package codecheck.github
+package events
 
 import org.json4s.jackson.JsonMethods
 

--- a/src/test/scala/events/PullRequestEventJson.scala
+++ b/src/test/scala/events/PullRequestEventJson.scala
@@ -1,4 +1,5 @@
-package codecheck.github.events
+package codecheck.github
+package events
 
 import org.json4s.jackson.JsonMethods
 


### PR DESCRIPTION
IMO, this makes the call stack traces easier to read, since the tests share the same namespace as the library code.

Many `import` statements that weren't necessary can be deleted.

The entire test suite can still be run with

    $ sbt
    > test

Individual tests that used to be run as

    $ sbt
    > testOnly UserOpSpec

Will now need to be run as

    $ sbt
    > testOnly codecheck.github.operations.UserOpSpec

I think that's ok