### PR TITLE
Add status API support resolves #68

### DIFF
--- a/src/main/scala/codecheck/github/api/GitHubAPI.scala
+++ b/src/main/scala/codecheck/github/api/GitHubAPI.scala
@@ -25,6 +25,7 @@ class GitHubAPI(token: String, client: Transport, tokenType: String = "token", d
   with IssueOp
   with PullRequestOp
   with MilestoneOp
+  with StatusOp
   with WebhookOp
   with CollaboratorOp
   with BranchOp

--- a/src/main/scala/codecheck/github/models/Status.scala
+++ b/src/main/scala/codecheck/github/models/Status.scala
@@ -1,0 +1,59 @@
+package codecheck.github
+package models
+
+import org.json4s.JValue
+import org.json4s.JArray
+
+sealed abstract class StatusState(override val toString: String)
+
+object StatusState {
+  case object pending extends StatusState("pending")
+  case object success extends StatusState("success")
+  case object error   extends StatusState("error")
+  case object failure extends StatusState("failure")
+
+  val values = Array(pending, success, error, failure)
+
+  def fromString(str: String) = values.filter(_.toString == str).head
+}
+
+case class Status(value: JValue) extends AbstractJson(value) {
+  def state = StatusState.fromString(get("state"))
+  def target_url = opt("target_url")
+  def description = opt("description")
+  def context = get("context")
+  def id = get("id").toLong
+  def url = get("url")
+  def created_at = getDate("created_at")
+  def updated_at = getDate("updated_at")
+  lazy val assignee = objectOpt("assignee")(v => User(v))
+}
+
+case class StatusInput(
+  state: StatusState,
+  target_url: Option[String] = None,
+  description: Option[String] = None,
+  context: Option[String] = None
+) extends AbstractInput {
+  import org.json4s.JsonDSL._
+
+  override val value: JValue =
+    ("state" -> state.toString) ~
+    ("target_url" -> target_url) ~
+    ("description" -> description) ~
+    ("context" -> context)
+}
+
+case class CombinedStatus(value: JValue) extends AbstractJson(value) {
+  def state = StatusState.fromString(get("state"))
+  def sha = get("sha")
+  lazy val statuses = (value \ "statuses") match {
+    case JArray(arr) => arr.map(Status(_))
+    case _ => Nil
+  }
+
+  def repository = Repository(value \ "repository")
+  def commit_url = get("commit_url")
+  def total_count = get("total_count").toLong
+  def url = get("url")
+}

--- a/src/main/scala/codecheck/github/operations/StatusOp.scala
+++ b/src/main/scala/codecheck/github/operations/StatusOp.scala
@@ -1,0 +1,42 @@
+package codecheck.github
+package operations
+
+import org.json4s.JArray
+
+import codecheck.github.models.CombinedStatus
+import codecheck.github.models.Status
+import codecheck.github.models.StatusInput
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait StatusOp {
+  self: api.GitHubAPI =>
+
+  def createStatus(owner: String, repo: String, sha: String, input: StatusInput): Future[Status] = {
+    val path = s"/repos/$owner/$repo/statuses/$sha"
+    exec("POST", path, input.value).map { result =>
+      Status(result.body)
+    }
+  }
+
+  def listStatus(owner: String, repo: String, sha: String): Future[List[Status]] = {
+    val path = s"/repos/$owner/$repo/commits/$sha/statuses"
+    exec("GET", path, fail404 = false).map { result =>
+      result.statusCode match {
+        case 404 => Nil
+        case _ => result.body match {
+          case JArray(arr) => arr.map(Status(_))
+          case _ => throw new IllegalStateException()
+        }
+      }
+    }
+  }
+
+  def getStatus(owner: String, repo: String, sha: String): Future[CombinedStatus] = {
+    val path = s"/repos/$owner/$repo/commits/$sha/status"
+    exec("GET", path).map { result =>
+      CombinedStatus(result.body)
+    }
+  }
+}

--- a/src/test/scala/Constants.scala
+++ b/src/test/scala/Constants.scala
@@ -34,6 +34,7 @@ trait Constants {
 
   protected val otherUser = "shunjikonishi"
   protected val otherUserRepo = "test-repo"
+  protected val otherSha = "364ca6d43b5aea6a82aab5cd576eb9ccad6da537"
   protected val collaboratorUser = "shunjikonishi"
   protected val otherUserInvalid = "loremipsom123"
   protected val organizationInvalid = "loremipsom123"

--- a/src/test/scala/Constants.scala
+++ b/src/test/scala/Constants.scala
@@ -31,10 +31,10 @@ trait Constants {
 
   protected val user = sys.env("GITHUB_USER")
   protected val userRepo = sys.env("GITHUB_REPO")
+  protected val userSha = "364ca6d43b5aea6a82aab5cd576eb9ccad6da537"
 
   protected val otherUser = "shunjikonishi"
   protected val otherUserRepo = "test-repo"
-  protected val otherSha = "364ca6d43b5aea6a82aab5cd576eb9ccad6da537"
   protected val collaboratorUser = "shunjikonishi"
   protected val otherUserInvalid = "loremipsom123"
   protected val organizationInvalid = "loremipsom123"

--- a/src/test/scala/StatusOpSpec.scala
+++ b/src/test/scala/StatusOpSpec.scala
@@ -1,13 +1,13 @@
-// package codecheck.github
-// package operations
+package codecheck.github
+package operations
 
-// import models._
+import models._
 
 import codecheck.github.models.Status
 import codecheck.github.models.StatusInput
 import codecheck.github.models.StatusState
 
-// import exceptions._
+import exceptions._
 
 import codecheck.github.exceptions.GitHubAPIException
 import codecheck.github.exceptions.NotFoundException
@@ -15,7 +15,7 @@ import codecheck.github.exceptions.NotFoundException
 import org.scalatest.FunSpec
 import scala.concurrent.Await
 
-class StatusOpSpec extends FunSpec with /*api.*/Constants {
+class StatusOpSpec extends FunSpec with api.Constants {
 
   describe("listStatus(owner, repo, sha)") {
 

--- a/src/test/scala/StatusOpSpec.scala
+++ b/src/test/scala/StatusOpSpec.scala
@@ -1,0 +1,76 @@
+// package codecheck.github
+// package operations
+
+// import models._
+
+import codecheck.github.models.Status
+import codecheck.github.models.StatusInput
+import codecheck.github.models.StatusState
+
+// import exceptions._
+
+import codecheck.github.exceptions.GitHubAPIException
+import codecheck.github.exceptions.NotFoundException
+
+import org.scalatest.FunSpec
+import scala.concurrent.Await
+
+class StatusOpSpec extends FunSpec with /*api.*/Constants {
+
+  describe("listStatus(owner, repo, sha)") {
+
+    it("should have zero or more statuses") {
+      val result = Await.result(api.listStatus(otherUser, otherUserRepo, otherSha), TIMEOUT)
+      result.map { status =>
+        assert(StatusState.values.contains(status.state))
+      }
+    }
+  }
+
+  describe("getStatus(owner, repo, sha)") {
+
+    it("should have a status or not") {
+      val result = Await.result(api.getStatus(otherUser, otherUserRepo, otherSha), TIMEOUT)
+      assert(StatusState.values.contains(result.state))
+      assert(result.sha == otherSha)
+      assert(result.total_count >= 0L)
+      assert(result.statuses.length >= 0L)
+      result.statuses.map { status =>
+        assert(StatusState.values.contains(status.state))
+      }
+    }
+  }
+
+  describe("createStatus(owner, repo, sha, input)") {
+
+    it("should be pending") {
+      val input = StatusInput(StatusState.pending)
+      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      assert(result.state == StatusState.pending)
+      assert(result.target_url == None)
+      assert(result.description == None)
+      assert(result.context == "default")
+    }
+
+    it("should be success") {
+      val input = StatusInput(StatusState.success, Some("http://"))
+      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      assert(result.state == StatusState.success)
+      assert(result.target_url == Some("http://"))
+    }
+
+    it("should be error") {
+      val input = StatusInput(StatusState.error, description = Some("Description"))
+      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      assert(result.state == StatusState.error)
+      assert(result.description == Some("Description"))
+    }
+
+    it("should be failure") {
+      val input = StatusInput(StatusState.failure, context = Some("context"))
+      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      assert(result.state == StatusState.failure)
+      assert(result.context == "context")
+    }
+  }
+}

--- a/src/test/scala/StatusOpSpec.scala
+++ b/src/test/scala/StatusOpSpec.scala
@@ -20,7 +20,7 @@ class StatusOpSpec extends FunSpec with api.Constants {
   describe("listStatus(owner, repo, sha)") {
 
     it("should have zero or more statuses") {
-      val result = Await.result(api.listStatus(otherUser, otherUserRepo, otherSha), TIMEOUT)
+      val result = Await.result(api.listStatus(user, userRepo, userSha), TIMEOUT)
       result.map { status =>
         assert(StatusState.values.contains(status.state))
       }
@@ -30,9 +30,9 @@ class StatusOpSpec extends FunSpec with api.Constants {
   describe("getStatus(owner, repo, sha)") {
 
     it("should have a status or not") {
-      val result = Await.result(api.getStatus(otherUser, otherUserRepo, otherSha), TIMEOUT)
+      val result = Await.result(api.getStatus(user, userRepo, userSha), TIMEOUT)
       assert(StatusState.values.contains(result.state))
-      assert(result.sha == otherSha)
+      assert(result.sha == userSha)
       assert(result.total_count >= 0L)
       assert(result.statuses.length >= 0L)
       result.statuses.map { status =>
@@ -45,7 +45,7 @@ class StatusOpSpec extends FunSpec with api.Constants {
 
     it("should be pending") {
       val input = StatusInput(StatusState.pending)
-      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      val result = Await.result(api.createStatus(user, userRepo, userSha, input), TIMEOUT)
       assert(result.state == StatusState.pending)
       assert(result.target_url == None)
       assert(result.description == None)
@@ -54,21 +54,21 @@ class StatusOpSpec extends FunSpec with api.Constants {
 
     it("should be success") {
       val input = StatusInput(StatusState.success, Some("http://"))
-      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      val result = Await.result(api.createStatus(user, userRepo, userSha, input), TIMEOUT)
       assert(result.state == StatusState.success)
       assert(result.target_url == Some("http://"))
     }
 
     it("should be error") {
       val input = StatusInput(StatusState.error, description = Some("Description"))
-      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      val result = Await.result(api.createStatus(user, userRepo, userSha, input), TIMEOUT)
       assert(result.state == StatusState.error)
       assert(result.description == Some("Description"))
     }
 
     it("should be failure") {
       val input = StatusInput(StatusState.failure, context = Some("context"))
-      val result = Await.result(api.createStatus(otherUser, otherUserRepo, otherSha, input), TIMEOUT)
+      val result = Await.result(api.createStatus(user, userRepo, userSha, input), TIMEOUT)
       assert(result.state == StatusState.failure)
       assert(result.context == "context")
     }


### PR DESCRIPTION
Can create, list and get combined status of a commit (or a reference for the latter two).

I've left namespaces commented out in advance of getting #66 merged.  Happy to fixup this pull request if you merge that one first.