### PR TITLE
Fix build for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-jackson" % "3.4.2",
   "org.json4s" %% "json4s-ext" % "3.4.2",
   "joda-time" % "joda-time" % "2.8.1",
-  "com.github.scopt" %% "scopt" % "3.3.0",
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+  "com.github.scopt" %% "scopt" % "3.5.0",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 val localRepo = "../sbt-repo"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := """github-api"""
 
 version := "0.2.0-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 // Change this to another test framework if you prefer
 libraryDependencies ++= Seq(


### PR DESCRIPTION
- Update scopt to 3.5.0
- Update scalatest to 3.0.1

```
> ++2.12.1
[info] Setting version to 2.12.1
[info] Reapplying settings...
[info] Set current project to github-api (in build file:github-api-scala/)
> compile
[info] Updating {file:github-api-scala/}github-api-scala...
[info] Resolving com.github.scopt#scopt_2.12;3.3.0 ...
[warn] 	module not found: com.github.scopt#scopt_2.12;3.3.0
[warn] ==== local: tried
[warn]   ~/.ivy2/local/com.github.scopt/scopt_2.12/3.3.0/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/com/github/scopt/scopt_2.12/3.3.0/scopt_2.12-3.3.0.pom
[info] Resolving org.scalatest#scalatest_2.12;2.2.6 ...
[warn] 	module not found: org.scalatest#scalatest_2.12;2.2.6
[warn] ==== local: tried
[warn]   ~/.ivy2/local/org.scalatest/scalatest_2.12/2.2.6/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/2.2.6/scalatest_2.12-2.2.6.pom
[info] Resolving jline#jline;2.14.1 ...
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: com.github.scopt#scopt_2.12;3.3.0: not found
[warn] 	:: org.scalatest#scalatest_2.12;2.2.6: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn] 	Note: Unresolved dependencies path:
[warn] 		com.github.scopt:scopt_2.12:3.3.0 (/Users/aaronhawley/git/github-api-scala/build.sbt#L10-20)
[warn] 		  +- io.code-check:github-api_2.12:0.2.0-SNAPSHOT
[warn] 		org.scalatest:scalatest_2.12:2.2.6 (/Users/aaronhawley/git/github-api-scala/build.sbt#L10-20)
[warn] 		  +- io.code-check:github-api_2.12:0.2.0-SNAPSHOT
[trace] Stack trace suppressed: run last *:update for the full output.
[error] (*:update) sbt.ResolveException: unresolved dependency: com.github.scopt#scopt_2.12;3.3.0: not found
[error] unresolved dependency: org.scalatest#scalatest_2.12;2.2.6: not found
[error] Total time: 5 s, completed Jan 23, 2017 8:24:34 AM 
```

The changes to scopt seem to only be non-breaking enhancements:

https://github.com/scopt/scopt/compare/3.3.0...v3.5.0

The gh-shell still works

```
$ env GITHUB_TOKEN=xxxx sbt
[info] Loading global plugins from ~/.sbt/0.13/plugins
[info] Loading project definition from github-api-scala/project
[info] Set current project to github-api (in build file:github-api-scala/)
> run
[info] Updating {file:github-api-scala/}github-api-scala...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Running codecheck.github.app.Main 
ashawley> help
Avaiable commands:
  - cr
  - issue
  - label
  - milestone
  - repo
ashawley> repo list --help
Error: Unknown option --help
Usage: label [list]

Command: list [options]
list repositories
  -u, --user <value>      List public repositories for the specified user.
  -o, --org <value>       List repositories for the specified org.
  --type <value>          Can be one of all, owner, public, private, member, forks, sources. Default: all
  --sort <value>          Can be one of created, updated, pushed, full_name. Default: full_name
  --direction <value>     The direction of the sort. Either asc or desc. Default: asc
ashawley> repo list -o code-check
name                          description                          issues  
---------------------------------------------------------------------------
env-builder                   Test environment builder             1       
github-api-scala              GitHubAPI wrapper for scala          18      
github-hook                                                        5       
test-repo                     Test repository for github-api-scala 3       
gh-shell                      GitHub Shell using github-api-scala  0       
codecheck                     codecheck CLI                        0       
challenge-fizzbuzz-js         codecheck challenge FizzBuzz for js  0       
fizzbuzz                                                           0       
docs                          Documentation for code-check.io.     0       
csharp-samples                                                     0       
challenge-arrays              Simple array challenge               0       
challenge-sudoku-easy         Easy sudoku challenge                0       
challenge-sudoku-medium       Medium sudoku challenge              0       
challenge-es6-firststep                                            0       
challenge-socket                                                   0       
challenge-binary-tostring                                          0       
challenge-rot13                                                    0       
challenge-rijndael-medium                                          0       
challenge-rijndael                                                 0       
challenge-entity-framework                                         0       
challenge-mvc-asp                                                  0       
challenge-eventapp                                                 0       
challenge-auth-hmac                                                0       
challenge-helloworld                                               1       
challenge-revel               Revel test                           0       
template-api-challenge        Template for api base challenge      0       
template-revel                                                     0       
challenge-circle-animation    Interactive Challenge...             0       
challenge-portfolio           Portfolio                            0       
challenge-sudoku-interactive                                       0       
ashawley> exit
Bye!
```