### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: scala
+
+scala:
+  - 2.10.6
+  - 2.11.7
+  - 2.12.1
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test:compile
+
+# Container-based build environment with faster boot times
+sudo: false
+
+jdk:
+  - oraclejdk8
+
+before_cache:
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+cache:
+  directories:
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt/boot
+  - $HOME/.sbt/launchers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GitHubAPI for scala
+[![Build Status](https://travis-ci.org/code-check/github-api-scala.svg?branch=master)](https://travis-ci.org/code-check/github-api-scala)
 GitHubAPI wrapper for scala
 
 ## Dependencies


### PR DESCRIPTION
Add a config for Travis that doesn't do a build or even run the test suite.  For now, just compile since the test suite requires GitHub write-access with an OAuth token.