### PR TITLE
Publish to Sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,25 @@ GitHubAPI wrapper for scala
 - json4s
 - async-http-client
 
-## How to develop
+## Getting started
+
 To develop this, you have to get GitHub API Token.  
 You can get it from [here](https://github.com/settings/applications).
+
+Add this library and an HTTP client library to your `build.sbt` file.
+Both versions 1.9 and 2.0 of the Asnyc HTTP Client are supported, so
+you choose.  Ning's HTTP client will request a log binding, so we'll
+provide a basic one.
+
+```
+libraryDependencies ++= Seq(
+  "com.ning" % "async-http-client" % "1.9.21",
+  "org.slf4j" % "slf4j-simple" % "1.7.24",
+  "io.code-check" %% "github-api" % "0.2.0"
+)
+```
+
+## How to develop
 
 ``` bash
 export GITHUB_USER=[Your GitHub username] 

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,22 @@ licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 homepage := Some(url("http://github.com/code-check/github-api-scala"))
 
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/code-check/github-api-scala"),
+    "scm:git@github.com:code-check/github-api-scala.git"
+  )
+)
+
+developers := List(
+  Developer(
+    id    = "shunjikonishi",
+    name  = "Shunji Konishi",
+    email = "@shunjikonishi",
+    url   = url("http://qiita.com/shunjikonishi")
+  )
+)
+
 publishMavenStyle := true
 
 publishTo := {
@@ -27,27 +43,6 @@ publishTo := {
 publishArtifact in Test := false
 
 pomIncludeRepository := { _ => false }
-
-pomExtra := (
-  <url>http://github.com/code-check/github-api-scala</url>
-  <licenses>
-    <license>
-      <name>MIT</name>
-      <url>http://opensource.org/licenses/MIT</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:code-check/github-api-scala.git</url>
-    <connection>scm:git@github.com:code-check/github-api-scala.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>shunjikonishi</id>
-      <name>Shunji Konishi</name>
-      <url>http://qiita.com/shunjikonishi</url>
-      </developer>
-  </developers>)
 
 // Change this to another test framework if you prefer
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,4 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
-val localRepo = "../sbt-repo"
-
-publishTo := Some(Resolver.file("givery repo",file(localRepo))(Patterns(true, Resolver.mavenStyleBasePattern)))
-
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,49 @@ version := "0.2.0-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1")
+
+description := "The GitHub API from Scala with Async HTTP Client (Netty)"
+
+licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
+
+homepage := Some(url("http://github.com/code-check/github-api-scala"))
+
+publishMavenStyle := true
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishArtifact in Test := false
+
+pomIncludeRepository := { _ => false }
+
+pomExtra := (
+  <url>http://github.com/code-check/github-api-scala</url>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>git@github.com:code-check/github-api-scala.git</url>
+    <connection>scm:git@github.com:code-check/github-api-scala.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>shunjikonishi</id>
+      <name>Shunji Konishi</name>
+      <url>http://qiita.com/shunjikonishi</url>
+      </developer>
+  </developers>)
+
 // Change this to another test framework if you prefer
 libraryDependencies ++= Seq(
   "com.ning" % "async-http-client" % "1.9.21" % "provided",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
It would be nice to have this published so the library could be used easier in projects.

  - Add meta information
  - Add POM bits
  - Enable sbt-pgp plugin
  - Add instructions to README

Directions on publishing:

http://www.scala-sbt.org/0.13/docs/Using-Sonatype.html