### PR TITLE
Fix build for Scala 2.10

### DIFF
--- a/src/main/scala/codecheck/github/app/CommandRunner.scala
+++ b/src/main/scala/codecheck/github/app/CommandRunner.scala
@@ -73,7 +73,7 @@ class CommandRunner(api: GitHubAPI) {
 
   def run = {
     prompt
-    Iterator.continually(scala.io.StdIn.readLine).takeWhile { s =>
+    Iterator.continually(Console.in.readLine).takeWhile { s =>
       val end = s == null || s.trim == "exit"
       if (end) {
         api.close


### PR DESCRIPTION
Just use `Console.in.readLine` instead of `StdIn.readLine`

    [error] src/main/scala/codecheck/github/app/CommandRunner.scala:76: object StdIn is not a member of package io
    [error]     Iterator.continually(scala.io.StdIn.readLine).takeWhile { s =>
    [error]                                   ^