### PR TITLE
Use slf4j-nop for testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-ext" % "3.4.2",
   "joda-time" % "joda-time" % "2.8.1",
   "com.github.scopt" %% "scopt" % "3.5.0",
+  "org.slf4j" % "slf4j-nop" % "1.7.22" % "test",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 


### PR DESCRIPTION
slf4j-api (imported by async-http-client) is complaining:

    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.