### PR TITLE
[WIP] Improving Issue handling

### DIFF
--- a/src/main/scala/codecheck/github/events/GitHubEvent.scala
+++ b/src/main/scala/codecheck/github/events/GitHubEvent.scala
@@ -18,7 +18,7 @@ trait GitHubEvent {
 
 object GitHubEvent {
   def apply(name: String, value: JValue): GitHubEvent = name match {
-    case "issue" => IssueEvent(name, value)
+    case "issues" => IssueEvent(name, value)
     case "issue_comment" => IssueCommentEvent(name, value)
     case "pull_request" => PullRequestEvent(name, value)
     case "pull_request_review" => PullRequestReviewEvent(name, value)

--- a/src/main/scala/codecheck/github/models/Issue.scala
+++ b/src/main/scala/codecheck/github/models/Issue.scala
@@ -203,7 +203,7 @@ case class Issue(value: JValue) extends AbstractJson(value) {
   def created_at = getDate("created_at")
   def updated_at = getDate("updated_at")
   def closed_at = dateOpt("closed_at")
-  def body = opt("body")
+  def body = get("body")
 
   lazy val closed_by = objectOpt("closed_by")(v => User(v))
 

--- a/src/main/scala/codecheck/github/models/PullRequest.scala
+++ b/src/main/scala/codecheck/github/models/PullRequest.scala
@@ -16,6 +16,8 @@ sealed abstract class PullRequestAction(val name: String) {
 object PullRequestAction {
   case object assigned    extends PullRequestAction("assigned")
   case object unassigned  extends PullRequestAction("unassigned")
+  case object review_requested       extends PullRequestAction("review_requested")
+  case object review_request_removed extends PullRequestAction("review_request_removed")
   case object labeled     extends PullRequestAction("labeled")
   case object unlabeled   extends PullRequestAction("unlabeled")
   case object opened      extends PullRequestAction("opened")

--- a/src/main/scala/codecheck/github/models/PullRequestReview.scala
+++ b/src/main/scala/codecheck/github/models/PullRequestReview.scala
@@ -43,7 +43,7 @@ object PullRequestReviewState {
 
 case class PullRequestReview(value: JValue) extends AbstractJson(value) {
   def id = get("id").toLong
-  def body = opt("body")
+  def body = get("body")
   def commit_id = get("commit_id")
   lazy val user = User(value \ "user")
   def state = PullRequestReviewState.fromString(get("state"))

--- a/src/test/scala/IssueOpSpec.scala
+++ b/src/test/scala/IssueOpSpec.scala
@@ -38,7 +38,7 @@ class IssueOpSpec extends FunSpec with api.Constants with BeforeAndAfterAll {
       assert(result.created_at.toDateTime(DateTimeZone.UTC).getMillis() - DateTime.now(DateTimeZone.UTC).getMillis() <= 5000)
       assert(result.updated_at.toDateTime(DateTimeZone.UTC).getMillis() - DateTime.now(DateTimeZone.UTC).getMillis() <= 5000)
       assert(result.closed_at.isEmpty)
-      assert(result.body.get == "testing")
+      assert(result.body == "testing")
       assert(result.closed_by.isEmpty)
     }
 
@@ -60,7 +60,7 @@ class IssueOpSpec extends FunSpec with api.Constants with BeforeAndAfterAll {
       assert(result.comments == 0)
       assert(result.created_at.toDateTime(DateTimeZone.UTC).getMillis() - DateTime.now(DateTimeZone.UTC).getMillis() <= 5000)
       assert(result.updated_at.toDateTime(DateTimeZone.UTC).getMillis() - DateTime.now(DateTimeZone.UTC).getMillis() <= 5000)
-      assert(result.body.get == "testing")
+      assert(result.body == "testing")
       assert(result.closed_by.isEmpty)
     }
   }
@@ -162,7 +162,7 @@ class IssueOpSpec extends FunSpec with api.Constants with BeforeAndAfterAll {
     it("should edit the issue in user's own repo.") {
       val result = Await.result(api.editIssue(user, userRepo, nUser, input), TIMEOUT)
       assert(result.title == "test issue edited")
-      assert(result.body.get == "testing again")
+      assert(result.body == "testing again")
       assert(result.labels.head.name == "bug")
       assert(result.state == IssueState.closed)
       assert(result.updated_at.toDateTime(DateTimeZone.UTC).getMillis() - DateTime.now(DateTimeZone.UTC).getMillis() <= 5000)
@@ -171,7 +171,7 @@ class IssueOpSpec extends FunSpec with api.Constants with BeforeAndAfterAll {
     it("should edit the issue in organization's repo.") {
       val result = Await.result(api.editIssue(organization, tRepo, nOrg, input), TIMEOUT)
       assert(result.title == "test issue edited")
-      assert(result.body.get == "testing again")
+      assert(result.body == "testing again")
       assert(result.milestone.isEmpty)
       assert(result.labels.isEmpty)
       assert(result.state == IssueState.closed)

--- a/src/test/scala/events/GitHubEventSpec.scala
+++ b/src/test/scala/events/GitHubEventSpec.scala
@@ -12,7 +12,7 @@ class GitHubEventSpec extends FunSpec with Matchers with Inside
     with PushEventJson {
 
   describe("GitHubEvent(issue, JValue)") {
-    val event = GitHubEvent("issue", issueEventJson)
+    val event = GitHubEvent("issues", issueEventJson)
 
     it("should yield IssueEvent") {
       event shouldBe a [IssueEvent]
@@ -21,7 +21,7 @@ class GitHubEventSpec extends FunSpec with Matchers with Inside
       inside(event) {
         case e @ IssueEvent(name, _) =>
           it("should have a name") {
-            assert(name === "issue")
+            assert(name === "issues")
           }
           it("should have an action") {
             assert(e.action === models.IssueAction.opened)
@@ -41,8 +41,8 @@ class GitHubEventSpec extends FunSpec with Matchers with Inside
               assert(issue.state === models.IssueState.open)
             }
             it("should have a body") {
-              val exp = "It looks like you accidently spelled 'commit' with two 't's."
-              assert(issue.body === Some(exp))
+              val exp = ""
+              assert(issue.body === exp)
             }
           }
       }
@@ -215,7 +215,7 @@ class GitHubEventSpec extends FunSpec with Matchers with Inside
             }
             it("should have a body") {
               val exp = "Looks great!"
-              assert(review.body === Some(exp))
+              assert(review.body === exp)
             }
           }
           it("should have a pull request") {

--- a/src/test/scala/events/IssueEventJson.scala
+++ b/src/test/scala/events/IssueEventJson.scala
@@ -52,7 +52,7 @@ trait IssueEventJson {
       |    "created_at": "2015-05-05T23:40:28Z",
       |    "updated_at": "2015-05-05T23:40:28Z",
       |    "closed_at": null,
-      |    "body": "It looks like you accidently spelled 'commit' with two 't's."
+      |    "body": ""
       |  },
       |  "repository": {
       |    "id": 35129377,


### PR DESCRIPTION
- Mod event name of Issue event. `issue` -> `issues`
- Mod `def body: Option[String]` -> `def body: String`
  - Because some model classes use `String` result and some others uses `Option[String]`. I'd like to unify it. (Event json always has `"body": ""`, so handle it as String is no problem.)
  - Issue
  - PullRequestReview
- Add `review_requestd` and `review_request_removed` to PullRequestAction

FYI @ashawley This PR includes breaking compatibility. (`def body` changed)
