### PR TITLE
Add Pull Request Review API

### DIFF
--- a/src/main/scala/codecheck/github/api/GitHubAPI.scala
+++ b/src/main/scala/codecheck/github/api/GitHubAPI.scala
@@ -24,6 +24,7 @@ class GitHubAPI(token: String, client: Transport, tokenType: String = "token", d
   with LabelOp
   with IssueOp
   with PullRequestOp
+  with PullRequestReviewOp
   with MilestoneOp
   with StatusOp
   with WebhookOp
@@ -57,6 +58,7 @@ class GitHubAPI(token: String, client: Transport, tokenType: String = "token", d
     request
       .setHeader("Authorization", s"$tokenType $token")
       .setHeader("Content-Type", "application/json")
+      .setHeader("Accept", "application/vnd.github.black-cat-preview+json")
     if (method == "PUT" && body == JNothing){
       request
         .setHeader("Content-Length", "0")

--- a/src/main/scala/codecheck/github/api/GitHubAPI.scala
+++ b/src/main/scala/codecheck/github/api/GitHubAPI.scala
@@ -58,7 +58,7 @@ class GitHubAPI(token: String, client: Transport, tokenType: String = "token", d
     request
       .setHeader("Authorization", s"$tokenType $token")
       .setHeader("Content-Type", "application/json")
-      .setHeader("Accept", "application/vnd.github.black-cat-preview+json")
+      .setHeader("Accept", "application/vnd.github.v3+json")
     if (method == "PUT" && body == JNothing){
       request
         .setHeader("Content-Length", "0")

--- a/src/main/scala/codecheck/github/models/PullRequestReview.scala
+++ b/src/main/scala/codecheck/github/models/PullRequestReview.scala
@@ -1,7 +1,27 @@
 package codecheck.github
 package models
 
+import org.json4s.JsonDSL._
+import org.json4s.JNull
 import org.json4s.JValue
+
+case class PullRequestReviewInput(
+  body: Option[String] = None,
+  event: Option[PullRequestReviewStateInput] = None,
+  comments: Seq[PullRequestReviewCommentInput] = Seq.empty[PullRequestReviewCommentInput]
+) extends AbstractInput {
+  override val value: JValue = {
+    ("body" -> body) ~
+    ("event" -> event.map(_.name)) ~
+    ("comments" -> comments.map(_.value))
+  }
+}
+
+case class PullRequestReviewCommentInput(
+  path: String,
+  position: Long,
+  body: String
+) extends AbstractInput
 
 sealed abstract class PullRequestReviewAction(val name: String) {
   override def toString = name
@@ -39,6 +59,24 @@ object PullRequestReviewState {
   )
 
   def fromString(str: String) = values.filter(_.name == str.toLowerCase).head
+}
+
+sealed abstract class PullRequestReviewStateInput(val name: String)
+
+object PullRequestReviewStateInput {
+  case object APPROVE         extends PullRequestReviewStateInput("APPROVE")
+  case object COMMENT         extends PullRequestReviewStateInput("COMMENT")
+  case object PENDING         extends PullRequestReviewStateInput("PENDING")
+  case object REQUEST_CHANGES extends PullRequestReviewStateInput("REQUEST_CHANGES")
+
+  val values = Array(
+    APPROVE,
+    COMMENT,
+    PENDING,
+    REQUEST_CHANGES
+  )
+
+  def fromString(str: String) = values.filter(_.name == str).head
 }
 
 case class PullRequestReview(value: JValue) extends AbstractJson(value) {

--- a/src/main/scala/codecheck/github/operations/PullRequestReviewOp.scala
+++ b/src/main/scala/codecheck/github/operations/PullRequestReviewOp.scala
@@ -1,0 +1,55 @@
+package codecheck.github.operations
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.json4s.JArray
+import org.json4s.JObject
+import org.json4s.JString
+
+import codecheck.github.api.GitHubAPI
+import codecheck.github.models.PullRequestReviewInput
+import codecheck.github.models.PullRequestReview
+
+trait PullRequestReviewOp {
+  self: GitHubAPI =>
+
+  def listPullRequestReviews(
+    owner: String,
+    repo: String,
+    number: Long
+  ): Future[List[PullRequestReview]] = {
+    exec("GET", s"/repos/$owner/$repo/pulls/$number/reviews").map(
+      _.body match {
+        case JArray(arr) => arr.map(v => PullRequestReview(v))
+        case _ => throw new IllegalStateException()
+      }
+    )
+  }
+
+  def getPullRequestReview(owner: String, repo: String, number: Long, id: Long): Future[Option[PullRequestReview]] = {
+    val path = s"/repos/$owner/$repo/pulls/$number/reviews/$id"
+    exec("GET", path, fail404=false).map(res => 
+      res.statusCode match {
+        case 404 => None
+        case 200 => Some(PullRequestReview(res.body))
+      }
+    )
+  }
+
+  def createPullRequestReview(owner: String, repo: String, number: Long, input: PullRequestReviewInput): Future[PullRequestReview] = {
+    val path = s"/repos/$owner/$repo/pulls/$number/reviews"
+    exec("POST", path, input.value).map { result =>
+      PullRequestReview(result.body)
+    }
+  }
+
+  def dismissPullRequestReview(owner: String, repo: String, number: Long, id: Long, message: String): Future[PullRequestReview] = {
+    val path = s"/repos/$owner/$repo/pulls/$number/reviews/$id/dismissals"
+    exec("PUT", path, JObject(List(
+      "message" -> JString(message)
+    ))).map { result =>
+      new PullRequestReview(result.body)
+    }
+  }
+
+}

--- a/src/test/scala/PullRequestOpSpec.scala
+++ b/src/test/scala/PullRequestOpSpec.scala
@@ -51,6 +51,7 @@ class PullRequestOpSpec extends FunSpec with api.Constants {
     val username = otherUser
     val reponame = otherUserRepo
 
+    // NOTE: Can only create pull requests for submitting user
     it("should success create and close") {
       val title = "Test Pull Request " + new Date().toString()
       val input = PullRequestInput(title, "githubapi-test-pr", "master", Some("PullRequest body"))

--- a/src/test/scala/PullRequestReviewOpSpec.scala
+++ b/src/test/scala/PullRequestReviewOpSpec.scala
@@ -1,0 +1,63 @@
+package codecheck.github
+package operations
+
+import models._
+
+import org.scalatest.FunSpec
+import scala.concurrent.Await
+import java.util.Date
+
+class PullRequestReviewOpSpec extends FunSpec with api.Constants {
+
+  describe("listPullRequestReviews") {
+    it("with valid repo should succeed") {
+      val list = Await.result(api.listPullRequestReviews(otherUser, otherUserRepo, 47), TIMEOUT)
+      assert(list.length >= 0)
+      assert(list.exists(_.id >= 0))
+      assert(list.exists(_.state == PullRequestReviewState.approved))
+      assert(list.exists(_.commit_id.size == shaSize))
+    }
+  }
+
+  describe("getPullRequestReview") {
+    it("with valid repo should succeed") {
+      val review = Await.result(api.getPullRequestReview(otherUser, otherUserRepo, 47, 32477105), TIMEOUT)
+      assert(review.size >= 0)
+      assert(review.exists(_.id >= 0))
+      assert(review.exists(_.state == PullRequestReviewState.approved))
+      assert(review.exists(_.commit_id.size == shaSize))
+    }
+  }
+
+  describe("createPullRequestReview(owner, repo, number, input)") {
+    val username = otherUser
+    val reponame = otherUserRepo
+
+    it("should success create and close") {
+      val body = "Test PR review " + new Date().toString()
+      val input = PullRequestReviewInput(
+        Some(body),
+        Some(PullRequestReviewStateInput.REQUEST_CHANGES),
+        Seq(
+          PullRequestReviewCommentInput(
+            "challenge.json",
+            1L,
+            "Comment body"
+          )
+        )
+      )
+
+      // NOTE: You can only add reviews to PRs that aren't your own
+      val result = Await.result(api.createPullRequestReview(username, reponame, 47, input), TIMEOUT)
+      assert(result.body == Some(body))
+      assert(result.state == PullRequestReviewState.changes_requested)
+
+      // NOTE: You can only dismiss reviews on repos you have rights
+      // val result2 = Await.result(api.dismissPullRequestReview(username, reponame, 47, result.id, "githubapi-test-pr-review"), TIMEOUT)
+      // assert(result.body == Some(body))
+      // assert(result.state == PullRequestReviewState.dismissed)
+    }
+
+  }
+
+}


### PR DESCRIPTION
Currently, this feature of GitHub's API is only available as a preview:

https://developer.github.com/changes/2016-12-14-reviews-api/

This will prove difficult to test, because you need to use multiple accounts to 

- create pull requests
- submit pull request reviews
- dismiss pull request reviews

The test suite only runs with a single account... :-(