### PR TITLE
 Add support for Scala 2.13.0-M2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ scala:
   - 2.10.6
   - 2.11.11
   - 2.12.2
+  - 2.13.0-M1
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test:compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.10.6
   - 2.11.11
   - 2.12.2
-  - 2.13.0-M1
+  - 2.13.0-M2
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test:compile

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.2.1-SNAPSHOT"
 
 scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1", "2.13.0-M1")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1", "2.13.0-M2")
 
 description := "The GitHub API from Scala with Async HTTP Client (Netty)"
 
@@ -48,12 +48,12 @@ pomIncludeRepository := { _ => false }
 libraryDependencies ++= Seq(
   "com.ning" % "async-http-client" % "1.9.21" % "provided",
   "org.asynchttpclient" % "async-http-client" % "2.0.15" % "provided",
-  "org.json4s" %% "json4s-jackson" % "3.5.2",
-  "org.json4s" %% "json4s-ext" % "3.5.2",
+  "org.json4s" %% "json4s-jackson" % "3.5.3",
+  "org.json4s" %% "json4s-ext" % "3.5.3",
   "joda-time" % "joda-time" % "2.8.1",
-  "com.github.scopt" %% "scopt" % "3.6.0",
+  "com.github.scopt" %% "scopt" % "3.7.0",
   "org.slf4j" % "slf4j-nop" % "1.7.22" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.3" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.2.1-SNAPSHOT"
 
 scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1", "2.13.0-M1")
 
 description := "The GitHub API from Scala with Async HTTP Client (Netty)"
 
@@ -48,12 +48,12 @@ pomIncludeRepository := { _ => false }
 libraryDependencies ++= Seq(
   "com.ning" % "async-http-client" % "1.9.21" % "provided",
   "org.asynchttpclient" % "async-http-client" % "2.0.15" % "provided",
-  "org.json4s" %% "json4s-jackson" % "3.4.2",
-  "org.json4s" %% "json4s-ext" % "3.4.2",
+  "org.json4s" %% "json4s-jackson" % "3.5.2",
+  "org.json4s" %% "json4s-ext" % "3.5.2",
   "joda-time" % "joda-time" % "2.8.1",
-  "com.github.scopt" %% "scopt" % "3.5.0",
+  "com.github.scopt" %% "scopt" % "3.6.0",
   "org.slf4j" % "slf4j-nop" % "1.7.22" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 )
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")


### PR DESCRIPTION
The 2.13.0-M2 release appeared on Jul-2017.  2.13.0-M3 was released a few weeks ago, but not all the dependencies are available, yet, so we can't use it.