### PR TITLE
Fix Java 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: scala
 
 scala:
-  - 2.10.6
-  - 2.11.11
-  - 2.12.2
+  - 2.10.7
+  - 2.11.12
+  - 2.12.4
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test:compile
@@ -12,7 +12,7 @@ script:
 sudo: false
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.4
+  - 2.12.6
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test:compile

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.2.1-SNAPSHOT"
 
 scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.10.7", scalaVersion.value, "2.12.4")
+crossScalaVersions := Seq("2.10.7", scalaVersion.value, "2.12.6")
 
 description := "The GitHub API from Scala with Async HTTP Client (Netty)"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := """github-api"""
 
 version := "0.2.1-SNAPSHOT"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1")
+crossScalaVersions := Seq("2.10.7", scalaVersion.value, "2.12.4")
 
 description := "The GitHub API from Scala with Async HTTP Client (Netty)"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17


### PR DESCRIPTION
Currently, the build fails to compile:

```
$ sbt
> update
> compile
[info] Compiling 71 Scala sources to target/scala-2.11/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.11.11. Compiling...
error: scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found.
```

Updating the sbt version fixes the build, as well as upgrading the Scala versions.

This migrates the Travis build to oraclejdk9.