### PR TITLE
Change head.repo on pull requests to Option

### DIFF
--- a/src/main/scala/codecheck/github/models/PullRequest.scala
+++ b/src/main/scala/codecheck/github/models/PullRequest.scala
@@ -56,7 +56,7 @@ case class PullRequestRef(value: JValue) extends AbstractJson(value) {
   def ref = get("ref")
   def sha = get("sha")
   lazy val user = User(value \ "user")
-  lazy val repo = Repository(value \ "repo")
+  lazy val repo = objectOpt("repo")(Repository(_))
 }
 
 case class PullRequest(value: JValue) extends AbstractJson(value) {

--- a/src/test/scala/PullRequestOpSpec.scala
+++ b/src/test/scala/PullRequestOpSpec.scala
@@ -24,9 +24,9 @@ class PullRequestOpSpec extends FunSpec with api.Constants {
       assert(list.exists(_.deletions == None))
       assert(list.exists(_.changed_files == None))
       assert(list.exists(_.maintainer_can_modify == None))
-      assert(list.exists(_.base.repo.full_name == s"$otherUser/$otherUserRepo"))
+      assert(list.exists(_.base.repo.exists(_.full_name == s"$otherUser/$otherUserRepo")))
       assert(list.exists(_.base.user.login == otherUser))
-      assert(list.exists(_.base.repo.name == otherUserRepo))
+      assert(list.exists(_.base.repo.exists(_.name == otherUserRepo)))
     }
   }
 


### PR DESCRIPTION
Pull requests can have their forks deleted:

- https://stackoverflow.com/questions/36071272/fix-unknown-repository-of-an-opened-pr-after-deleted-the-fork
- https://github.com/isaacs/github/issues/168

This means the `head.repo` could be `null`, although this isn't documented in the API doc for listing pull requests:

https://developer.github.com/v3/pulls/#list-pull-requests

This causes github-api to throw an exception:
```
java.util.NoSuchElementException: None.get
```
Here's how to recreate the bug with a JSON payload in a file.

```scala
import org.json4s.JArray
import org.json4s.jackson.JsonMethods.parse
import codecheck.github.models.PullRequest

val json = scala.io.Source.fromFile("data/prs.json").getLines.mkString
parse(json).asInstanceOf[JArray].arr.map(PullRequest(_)).map(_.head.repo.name)
```