### PR TITLE
Add openjdk11 back to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ sudo: false
 
 jdk:
   - openjdk8
+  - openjdk11
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm


### PR DESCRIPTION
Easier to drop 2.10 and 2.11 from the build and openjdk is available, now.
