### PR TITLE
Fix broken test in GitHubEventSpec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
   - 2.13.0
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test:compile
+  - sbt ++$TRAVIS_SCALA_VERSION test:compile "testOnly *GitHubEventSpec"
 
 # Container-based build environment with faster boot times
 sudo: false

--- a/src/test/scala/events/GitHubEventSpec.scala
+++ b/src/test/scala/events/GitHubEventSpec.scala
@@ -176,7 +176,7 @@ class GitHubEventSpec extends FunSpec with Matchers with Inside
                 head.user shouldBe a [models.User]
               }
               it("should have a repo") {
-                head.repo shouldBe a [models.Repository]
+                head.repo.get shouldBe a [models.Repository]
               }
             }
             it("should have a base") {
@@ -254,7 +254,7 @@ class GitHubEventSpec extends FunSpec with Matchers with Inside
                 head.user shouldBe a [models.User]
               }
               it("should have a repo") {
-                head.repo shouldBe a [models.Repository]
+                head.repo.get shouldBe a [models.Repository]
               }
             }
             it("should have a base") {


### PR DESCRIPTION
In the change in #97, I should have changed the test.  I assumed the compiler would fail to typecheck and compile if something in the test suite needed to be updated,  but the ScalaTest matcher used is for `Any` type.
```
> testOnly codecheck.github.events.GitHubEventSpec
[error] Some(Repository) was not an instance of Repository, but an
[error] instance of scala.Some
```